### PR TITLE
Correct wikidata ID for date of death property in SPARQL query

### DIFF
--- a/artscraper/find_artworks.py
+++ b/artscraper/find_artworks.py
@@ -79,7 +79,7 @@ class FindArtworks:
                     BIND(geof:longitude(?coordinatesBirth) AS ?longitudeOfPlaceOfBirth)
                   }
                   OPTIONAL {
-                      wd:person_id wdt:P569 ?dateTimeOfDeath.
+                      wd:person_id wdt:P570 ?dateTimeOfDeath.
                       BIND (xsd:date(?dateTimeOfDeath) AS ?dateOfDeath)
                   }
                   OPTIONAL { wd:person_id wdt:P20 ?placeOfDeath. }


### PR DESCRIPTION
Hi @jgarciab:

I had the wrong ID for the "date of death" property in the SPARQL query. I have now fixed it. Can you please accept the pull request?

Thanks,
Modhurita